### PR TITLE
When creating a new base page, set the nextpage uri for the previously-last page page.

### DIFF
--- a/src/main/java/org/eclipse/lyo/oslc4j/trs/server/InmemPagedTrs.java
+++ b/src/main/java/org/eclipse/lyo/oslc4j/trs/server/InmemPagedTrs.java
@@ -236,6 +236,7 @@ public class InmemPagedTrs implements PagedTrs, ResourceEventHandler {
             final Base lastBase = getLastBaseResource();
             if (isBaseFull(lastBase)) {
                 page = createBase();
+                lastBase.getNextPage().setNextPage(page.getNextPage().getAbout());
             } else {
                 page = lastBase;
             }
@@ -253,7 +254,7 @@ public class InmemPagedTrs implements PagedTrs, ResourceEventHandler {
         final Base base = new Base();
         base.setAbout(this.createBaseUri());
         base.setNextPage(createBasePage(base, nextBasePageId()));
-
+        base.setCutoffEvent(URI.create(TRSConstants.RDF_NIL));
         log.debug("Adding a new Base resource");
         baseResources.add(base);
         return base;


### PR DESCRIPTION
When creating a new base page, set the nextpage uri for the previously-last page page.

Also, set the cuttoff event for each base page to rdf:nil (IBM LQE
fails, unless such an event is not there.)